### PR TITLE
Add optionnal govbar and fix extra head (fix #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Then, define the installed theme as current in you `udata.cfg`:
 THEME = 'gouvlu'
 ```
 
+### configuration parameters
+
+Some features are optionnal and can be enabled with the following `udata.cfg` parameters
+
+- `GOUVLU_GOVBAR = True/False`: Toggle the govbar
+
+
 ## Development
 
 There is a `docker-compose` configuration to get started fast.

--- a/gouvlu/theme/templates/raw.html
+++ b/gouvlu/theme/templates/raw.html
@@ -1,7 +1,7 @@
 
 {% extends "raw.html" %}
 
-{% block raw_head %}
+{% block extra_head %}
 {{ super() }}
 <link rel="shortcut icon" href="{{ theme_static('img/favicon/default.png') }}">
 <link rel="apple-touch-icon" sizes="57x57" href="{{ theme_static('img/favicon/57x57.png') }}">
@@ -22,4 +22,13 @@
 <meta name="msapplication-TileImage" content="{{ theme_static('img/favicon/144x144.png') }}">
 <meta name="msapplication-TileColor" content="{{ current_theme.info.color }}">
 <meta name="theme-color" content="{{ current_theme.info.color }}">
+{% endblock %}
+
+
+{% block extra_js %}
+{{ super() }}
+{% if config.GOUVLU_GOVBAR %}
+<script src="//cdn.public.lu/skizz/govbar/2-2-0/govbar.js" data-govbar="{ }"></script>
+<script>govbar();</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
This PRs optionnaly adds the govbar (as it relies on external assets).
To enable the govbar you need to set `GOUVLU_GOVBAR = True` in you `udata.cfg`.

No needs to add extra CSS, the govbar script includes everything.

## Desktop version
![screenshot-data xps-2018-01-17-21-19-27-213](https://user-images.githubusercontent.com/15725/35065068-5621e4c4-fbcc-11e7-8bd1-affd9eb7a9a2.png)

## Mobile version
![screenshot-data xps-2018-01-17-21-20-11-538](https://user-images.githubusercontent.com/15725/35065069-5829d48e-fbcc-11e7-93ae-7d6855316c9b.png)

