### PR TITLE
Use the dataset reuses cards

### DIFF
--- a/gouvlu/theme/templates/dataset/reuse-card.html
+++ b/gouvlu/theme/templates/dataset/reuse-card.html
@@ -1,0 +1,1 @@
+{% include theme('reuse/card.html') %}


### PR DESCRIPTION
This PR make use of reuse cards on dataset page.

Requires `udata>=1.2.10` with https://github.com/opendatateam/udata/pull/1378 to be visible