### PR TITLE
Style producer sidebar (fix #38)

### DIFF
--- a/assets/less/theme.less
+++ b/assets/less/theme.less
@@ -18,3 +18,4 @@
 @import 'widgets/cards';
 @import 'widgets/discussions';
 @import 'widgets/mobile-menu';
+@import 'widgets/producer-sidebar';

--- a/assets/less/widgets/producer-sidebar.less
+++ b/assets/less/widgets/producer-sidebar.less
@@ -1,0 +1,10 @@
+.panel {
+    img.certified {
+        position: absolute;
+        top: -15px;
+        right: -5px;
+        width: 70px;
+        height: 70px;
+        cursor: pointer;
+    }
+}

--- a/gouvlu/theme/templates/organization/sidebar-producer.html
+++ b/gouvlu/theme/templates/organization/sidebar-producer.html
@@ -1,0 +1,7 @@
+{% if organization.public_service %}
+<img src="{{ theme_static('img/certified-stamp.png')}}" alt="certified" class="certified"
+    v-popover.literal="{{ _('The identity of this public service public is certified by Data.public.lu') }}"
+    popover-title="{{ _('Certified public service') }}"
+    popover-placement="left" popover-trigger="hover"/>
+{% endif %}
+{% include 'organization/sidebar-producer.html' %}


### PR DESCRIPTION
Adds the missing certified stamp on producer sidebar

![screenshot-data xps-2018 02 06-18-38-57](https://user-images.githubusercontent.com/15725/35874862-e6bf8ada-0b6d-11e8-829e-0c0f22d5342f.png)
