### PR TITLE
Fix the translatable header (fix #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add the missing topics theme
+- Fix the translatable header [#81](https://github.com/opendatalu/gouvlu/pull/81)
 
 ## 1.0.2
 

--- a/assets/less/common/header.less
+++ b/assets/less/common/header.less
@@ -19,8 +19,13 @@
                 height: 100%;
             }
 
-            @media (max-width: @grid-float-breakpoint-max) {
+            @media (min-width: @screen-sm-min) and (max-width: @grid-float-breakpoint-max) {
                 height: 60px;
+                padding: 5px;
+            }
+
+            @media (max-width: @screen-sm-max) {
+                height: 55px;
                 padding: 5px;
             }
 
@@ -32,17 +37,27 @@
             margin: 30px 0 0 @spacing;
             padding-left: @spacing;
             border-left: 1px solid @brand-primary;
-            width: 200px;
+            width: 275px;
             font-size: 22px;
             line-height: 23px;
+            white-space: pre-line;
 
-            @media (max-width: @grid-float-breakpoint-max) {
+            @media (min-width: @screen-sm-min) and (max-width: @grid-float-breakpoint-max) {
                 @spacing: 5px;
                 margin: 10px 0 0 @spacing;
                 padding-left: @spacing;
                 font-size: 18px;
                 line-height: 21px;
-                width: 180px;
+                width: 220px;
+            }
+
+            @media (max-width: @screen-sm-max) {
+                @spacing: 5px;
+                margin: 10px 0 0 @spacing;
+                padding-left: @spacing;
+                font-size: 16px;
+                line-height: 21px;
+                width: 190px;
             }
         }
     }

--- a/gouvlu/theme/templates/header.html
+++ b/gouvlu/theme/templates/header.html
@@ -15,7 +15,7 @@
             <a class="navbar-brand" href="{{ url_for('site.home') }}">
                 <img class="header-logo" src="{{ theme_static('img/logo-bloc-borderless.svg') }}" alt="{{ g.site.title }}" />
             </a>
-            <p class="navbar-slogan">{{ _('The luxembourgish data platform') }}</p>
+            <p class="navbar-slogan">{{ _('The luxembourgish\n data platform') }}</p>
         </div>
         <nav class="navbar-collapse collapse">
             <ul class="nav navbar-nav">

--- a/gouvlu/theme/translations/fr/LC_MESSAGES/gouvlu.po
+++ b/gouvlu/theme/translations/fr/LC_MESSAGES/gouvlu.po
@@ -112,8 +112,8 @@ msgid "Toggle navigation"
 msgstr "Navigation"
 
 #: templates/header.html:18 templates/mobile-menu.html:6
-msgid "The luxembourgish data platform"
-msgstr "La plate-forme de données luxembourgeoise"
+msgid "The luxembourgish\n data platform"
+msgstr "La plate-forme de\n données luxembourgeoise"
 
 #: templates/header.html:40 templates/mobile-menu.html:39
 msgid "Browse by theme"

--- a/gouvlu/theme/translations/gouvlu.pot
+++ b/gouvlu/theme/translations/gouvlu.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-02-21 16:39+0100\n"
+"POT-Creation-Date: 2018-04-04 10:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,8 +25,7 @@ msgstr ""
 msgid "Datasets"
 msgstr ""
 
-#: __init__.py:21 templates/dataset/card.html:25 templates/footer.html:65
-#: templates/footer.html:67
+#: __init__.py:21 templates/footer.html:65 templates/footer.html:67
 msgid "Reuses"
 msgstr ""
 
@@ -111,8 +110,10 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/header.html:18 templates/mobile-menu.html:6
-msgid "The luxembourgish data platform"
+#: templates/header.html:18
+msgid ""
+"The luxembourgish\n"
+" data platform"
 msgstr ""
 
 #: templates/header.html:40 templates/mobile-menu.html:39
@@ -148,32 +149,32 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
+#: templates/home.html:10 templates/topic/display.html:8
+msgid "Featured reuses"
+msgstr ""
+
+#: templates/home.html:11 templates/topic/display.html:9
+msgid "Featured datasets"
+msgstr ""
+
+#: templates/home.html:15 templates/topic/display.html:10
+msgid "Latest reuses"
+msgstr ""
+
+#: templates/home.html:18 templates/topic/display.html:13
+msgid "Latest datasets"
+msgstr ""
+
+#: templates/mobile-menu.html:6
+msgid "The luxembourgish data platform"
+msgstr ""
+
 #: templates/terms.html:4 templates/terms.html:5
 msgid "Terms"
 msgstr ""
 
 #: templates/terms.html:7
 msgid "terms"
-msgstr ""
-
-#: templates/dataset/card.html:32 templates/reuse/card.html:23
-msgid "Stars"
-msgstr ""
-
-#: templates/dataset/card.html:42
-msgid "Territorial coverage"
-msgstr ""
-
-#: templates/dataset/card.html:52
-msgid "Territorial coverage granularity"
-msgstr ""
-
-#: templates/dataset/card.html:62
-msgid "Temporal coverage"
-msgstr ""
-
-#: templates/dataset/card.html:72
-msgid "Frequency"
 msgstr ""
 
 #: templates/organization/sidebar-producer.html:3
@@ -192,28 +193,15 @@ msgstr ""
 msgid "Number of datasets used"
 msgstr ""
 
-#: templates/sections/featured-datasets.html:5
-msgid "Featured datasets"
+#: templates/reuse/card.html:23
+msgid "Stars"
 msgstr ""
 
-#: templates/sections/featured-reuses.html:6
-msgid "Featured reuses"
+#: templates/sections/datasets.html:24 templates/sections/reuses.html:23
+msgid "See more"
 msgstr ""
 
 #: templates/sections/last-post.html:7
 msgid "News in data"
-msgstr ""
-
-#: templates/sections/latest-datasets.html:6
-msgid "Latest datasets"
-msgstr ""
-
-#: templates/sections/latest-datasets.html:22
-#: templates/sections/latest-reuses.html:20
-msgid "See more"
-msgstr ""
-
-#: templates/sections/latest-reuses.html:6
-msgid "Latest reuses"
 msgstr ""
 

--- a/gouvlu/translations/gouvlu.pot
+++ b/gouvlu/translations/gouvlu.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: gouvlu 0.1.6.dev0\n"
+"Project-Id-Version: gouvlu 1.0.3.dev0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-02-21 16:39+0100\n"
+"POT-Creation-Date: 2018-04-04 10:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,7 +52,7 @@ msgstr ""
 #: gouvlu/templates/faq/citizen.html:5 gouvlu/templates/faq/developer.html:5
 #: gouvlu/templates/faq/home.html:5 gouvlu/templates/faq/producer.html:5
 #: gouvlu/templates/faq/reuser.html:5 gouvlu/templates/faq/system-integrator.html:5
-msgid "Questions fréquemment posées sur la plateforme data.gouv.fr"
+msgid "Questions fréquemment posées sur la plateforme data.public.lu"
 msgstr ""
 
 #: gouvlu/templates/faq/developer.html:4


### PR DESCRIPTION
This PR fix the header tagline positionning.

To stay coherent, the line carriage is part of the translation and rendered

## Desktop

### English
![screenshot-data xps-2018 04 04-11-04-08](https://user-images.githubusercontent.com/15725/38298950-177d5bc2-37f9-11e8-9f4d-189c6e1a1aea.png)

### French
![screenshot-data xps-2018 04 04-11-03-40](https://user-images.githubusercontent.com/15725/38298953-19d05a32-37f9-11e8-98a8-effb1308d7ce.png)

## Mobile

### English
![screenshot-data xps-2018 04 04-11-06-12](https://user-images.githubusercontent.com/15725/38298944-12706714-37f9-11e8-8769-a8640642a1ec.png)

### French
![screenshot-data xps-2018 04 04-11-07-49](https://user-images.githubusercontent.com/15725/38298945-13e2ad64-37f9-11e8-9d74-3fe59e319971.png)
