### PR TITLE
Use assets manifest and udata 1.6 theme changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           command: |
             virtualenv venv
             source venv/bin/activate
+            pip install -e . || pip install -e .
             pip install -r requirements/develop.pip || pip install -r requirements/develop.pip
       - save_cache:
           key: py-cache-v3-{{ arch }}-{{ .Branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ENV/
 # assets
 /node_modules
 /gouvlu/theme/static/
+/gouvlu/theme/manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Use an assets manifest for improved caching [#102](https://github.com/opendatalu/gouvlu/pull/102)
+- Expose theme assets for udata 1.6 [#102](https://github.com/opendatalu/gouvlu/pull/102)
 
 ## 1.1.1 (2018-09-11)
 

--- a/gouvlu/theme/templates/oembed.html
+++ b/gouvlu/theme/templates/oembed.html
@@ -1,5 +1,5 @@
 {% extends 'oembed.html' %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ theme_static('oembed.css', external=True) }}" />
+<link href="{{ manifest('theme', 'oembed.css', external=True) }}" rel="stylesheet">
 {% endblock %}

--- a/gouvlu/theme/templates/raw.html
+++ b/gouvlu/theme/templates/raw.html
@@ -24,6 +24,11 @@
 <meta name="theme-color" content="{{ current_theme.info.color }}">
 {% endblock %}
 
+{% block theme_css %}
+{{ super() }}
+<link href="{{ manifest('theme', 'theme.css') }}" rel="stylesheet">
+{% endblock %}
+
 
 {% block extra_js %}
 {{ super() }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,6 +2067,17 @@
         "readable-stream": "2.3.3"
       }
     },
+    "fs-extra": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2829,6 +2840,15 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5582,6 +5602,12 @@
         "imurmurhash": "0.1.4"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -6339,6 +6365,17 @@
             "has-flag": "3.0.0"
           }
         }
+      }
+    },
+    "webpack-manifest-plugin": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
+      "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "7.0.0",
+        "lodash": "4.17.4",
+        "tapable": "1.0.0"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "style-loader": "^0.21.0",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "webpack": "^4.16.3",
-    "webpack-cli": "^3.1.0"
+    "webpack-cli": "^3.1.0",
+    "webpack-manifest-plugin": "^2.0.4"
   },
   "dependencies": {
     "bootstrap": "^3.3.7",

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
-udata>=1.5.3
+udata>=1.6.0
 feedparser
 requests==2.19.1

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,11 @@ const path = require('path');
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const ManifestPlugin = require('webpack-manifest-plugin');
 
-const static_path = path.resolve('./gouvlu/theme/static');
+const public_path = '/_themes/gouvlu/';
+const theme_path = path.resolve('./gouvlu/theme');
+const static_path = path.join(theme_path, 'static');
 const source_path = path.resolve('./assets');
 
 module.exports = function(env, argv) {
@@ -18,8 +21,9 @@ module.exports = function(env, argv) {
         },
         output: {
             path: static_path,
-            publicPath: "/_themes/gouvlu/",
-            filename: "[name].js"
+            publicPath: public_path,
+            filename: "[name].[hash].js",
+            chunkFilename: 'chunks/[id].[hash].js'
         },
         resolve: {
             modules: [
@@ -35,15 +39,21 @@ module.exports = function(env, argv) {
                     {loader: 'less-loader', options: {sourceMap: true}},
                 ]},
                 {test: /img\/.*\.(jpg|jpeg|png|gif|svg)$/, loader: 'file-loader', options: {
-                    name: '[path][name].[ext]?[hash]', context: source_path
+                    name: '[path][name].[ext]', context: source_path
                 }},
             ]
         },
         devtool: isProd ? 'source-map' : 'eval',
         plugins: [
+            new ManifestPlugin({
+                fileName: path.join(theme_path, 'manifest.json'),
+                // Filter out chunks and source maps
+                filter: ({name, isInitial, isChunk}) => !name.endsWith('.map') && (isInitial || !isChunk),
+                publicPath: public_path,
+            }),
             new MiniCssExtractPlugin({
-                filename: "[name].css",
-                chunkFilename: "[id].css"
+                filename: '[name].[hash].css',
+                chunkFilename: '[id].[hash].css',
             }),
         ]
     };


### PR DESCRIPTION
This PR:
- expose theme assets in the templates as required by udata 1.6
- make use of assets manifest for improved cache handling
- raise udata dependency to 1.6+

(OEmbed change will require the soon to come udata 1.6.2)